### PR TITLE
create Intercom user on new event, if doesn't exists

### DIFF
--- a/handlers/middleware_test.go
+++ b/handlers/middleware_test.go
@@ -13,7 +13,7 @@ func TestAuthMiddlewareWhenAPIKeyIsValid(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	req.Header.Add("FORWARDLYTICS_API_KEY", `DNUAS67AASNDj`)
+	req.Header.Add("Forwardlytics-Api-Key", `DNUAS67AASNDj`)
 	rr := httptest.NewRecorder()
 
 	AuthMiddleware(FakeHandler{}).ServeHTTP(rr, req)
@@ -36,7 +36,7 @@ func TestAuthMiddlewareWhenAPIKeyIsInvalid(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	req.Header.Add("FORWARDLYTICS_API_KEY", `...`)
+	req.Header.Add("Forwardlytics-Api-Key", `...`)
 	rr := httptest.NewRecorder()
 
 	AuthMiddleware(FakeHandler{}).ServeHTTP(rr, req)
@@ -46,7 +46,7 @@ func TestAuthMiddlewareWhenAPIKeyIsInvalid(t *testing.T) {
 			status, http.StatusUnauthorized)
 	}
 
-	expected := `{"message": "Invalid API KEY. The FORWARDLYTICS_API_KEY header must be specified, with the proper API key."}`
+	expected := `{"message": "Invalid API KEY. The Forwardlytics-Api-Key header must be specified, with the proper API key."}`
 	if rr.Body.String() != expected {
 		t.Errorf("handler returned unexpected body: got %v want %v",
 			rr.Body.String(), expected)


### PR DESCRIPTION
I think this can happen if events are coming super fast, faster than an identify call.

TODO:
- [x] add test