### PR TITLE
Page tracking endpoint added

### DIFF
--- a/handlers/fake_integration.go
+++ b/handlers/fake_integration.go
@@ -16,7 +16,7 @@ func (fi FakeIntegration) Track(event integrations.Event) error {
 	return nil
 }
 
-// Enabled returns wether or not the integration is enabled/configured
+// Page forwards the page-view data to the integration
 func (fi FakeIntegration) Page(page integrations.Page) error {
 	return nil
 }

--- a/handlers/fake_integration.go
+++ b/handlers/fake_integration.go
@@ -17,6 +17,11 @@ func (fi FakeIntegration) Track(event integrations.Event) error {
 }
 
 // Enabled returns wether or not the integration is enabled/configured
+func (fi FakeIntegration) Page(page integrations.Page) error {
+	return nil
+}
+
+// Enabled returns wether or not the integration is enabled/configured
 func (fi FakeIntegration) Enabled() bool {
 	return true
 }

--- a/handlers/page.go
+++ b/handlers/page.go
@@ -1,0 +1,68 @@
+package handlers
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/Sirupsen/logrus"
+	"github.com/codeship/go-retro"
+	"github.com/jipiboily/forwardlytics/integrations"
+)
+
+// Page is taking a pageview to send it to the enabled integrations
+func Page(w http.ResponseWriter, r *http.Request) {
+	// This is the soonest we can do that, pretty much at least.
+	receivedAt := time.Now().Unix()
+
+	// This endpoint is a POST, everything else be a 404
+	if r.Method != "POST" {
+		http.NotFound(w, r)
+		return
+	}
+
+	// Unmarshal input JSON
+	decoder := json.NewDecoder(r.Body)
+	var page integrations.Page
+	err := decoder.Decode(&page)
+	if err != nil {
+		logrus.WithField("err", err).WithField("body", r.Body).Error("Bad request in Page")
+		writeResponse(w, "Invalid request.", http.StatusBadRequest)
+		return
+	}
+	page.ReceivedAt = receivedAt
+
+	// Input validation
+	missingParameters := page.Validate()
+	if len(missingParameters) != 0 {
+		msg := "Missing parameters: "
+		msg = msg + strings.Join(missingParameters, ", ") + "."
+		writeResponse(w, msg, http.StatusBadRequest)
+		return
+	}
+
+	// Yay, it worked so far, let's send all the things to integrations!
+	for _, integrationName := range integrations.IntegrationList() {
+		integration := integrations.GetIntegration(integrationName)
+		if integration.Enabled() {
+			logrus.Infof("Forwarding page to %s", integrationName)
+			err := retro.DoWithRetry(func() error {
+				e := integration.Page(page)
+				if e != nil {
+					return resourceNotReady(e)
+				}
+				return e
+			})
+			if err != nil {
+				errMsg := fmt.Sprintf("Fatal error during page with an integration (%s): %s", integrationName, err)
+				logrus.WithField("integration", integrationName).WithField("page", page).WithField("err", err).Error("Fatal error during page")
+				writeResponse(w, errMsg, 500)
+				return
+			}
+		}
+	}
+
+	writeResponse(w, "Forwarding page to integrations.", http.StatusOK)
+}

--- a/handlers/page_test.go
+++ b/handlers/page_test.go
@@ -1,0 +1,185 @@
+package handlers
+
+import (
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/jipiboily/forwardlytics/integrations"
+)
+
+func TestPageWhenNotPOST(t *testing.T) {
+	expectedStatusCode := 404
+	expectedBody := "404 page not found"
+
+	r, err := http.NewRequest("GET", "/page", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	w := httptest.NewRecorder()
+
+	Page(w, r)
+
+	if w.Code != expectedStatusCode {
+		t.Errorf(`Wrong status code. Expecting %v but got %v`, expectedStatusCode, w.Code)
+	}
+
+	if !strings.Contains(w.Body.String(), expectedBody) {
+		t.Errorf(`Wrong response. Expecting "%s" but got "%s"`, expectedBody, w.Body.String())
+	}
+}
+
+func TestPageWhenInvalidJSON(t *testing.T) {
+	expectedStatusCode := 400
+	expectedBody := `{"message": "Invalid request."}`
+
+	requestBody := `invalid JSON here`
+	r, err := http.NewRequest("POST", "/page", strings.NewReader(requestBody))
+	if err != nil {
+		t.Fatal(err)
+	}
+	w := httptest.NewRecorder()
+
+	Page(w, r)
+
+	if w.Code != expectedStatusCode {
+		t.Errorf("Wrong status code. Expecting %v but got %v", expectedStatusCode, w.Code)
+	}
+
+	if !strings.Contains(w.Body.String(), expectedBody) {
+		t.Errorf(`Wrong response. Expecting "%s" but got "%s"`, expectedBody, w.Body.String())
+	}
+}
+
+func TestPageWhenMissingParameter(t *testing.T) {
+	expectedStatusCode := 400
+	expectedBody := `{"message": "Missing parameters: name, url, userID, timestamp."}`
+
+	requestBody := `{}`
+	r, err := http.NewRequest("POST", "/page", strings.NewReader(requestBody))
+	if err != nil {
+		t.Fatal(err)
+	}
+	w := httptest.NewRecorder()
+
+	Page(w, r)
+
+	if w.Code != expectedStatusCode {
+		t.Errorf("Wrong status code. Expecting %v but got %v", expectedStatusCode, w.Code)
+	}
+
+	if !strings.Contains(w.Body.String(), expectedBody) {
+		t.Errorf(`Wrong response. Expecting "%s" but got "%s"`, expectedBody, w.Body.String())
+	}
+}
+
+func TestPageWhenOneIntegrationFails(t *testing.T) {
+	expectedStatusCode := 500
+	expectedBody := `{"message": "Fatal error during page with an integration (test-only-integration-failing): some random error"}`
+
+	requestBody := `{
+		"name":"something.created",
+		"userID":"123",
+                "url":"http://www.example.com",
+		"properties": { "someCounter": 97 },
+		"timestamp": 12345678
+	}`
+	r, err := http.NewRequest("POST", "/page", strings.NewReader(requestBody))
+	if err != nil {
+		t.Fatal(err)
+	}
+	w := httptest.NewRecorder()
+
+	failingIntegration := FailingIntegrationPage{}
+	integrations.RegisterIntegration("test-only-integration-failing", failingIntegration)
+	defer integrations.RemoveIntegration("test-only-integration-failing")
+
+	workingIntegration := FakeIntegration{}
+	integrations.RegisterIntegration("test-only-integration-working", workingIntegration)
+	defer integrations.RemoveIntegration("test-only-integration-working")
+
+	Page(w, r)
+
+	if w.Code != expectedStatusCode {
+		t.Errorf("Wrong status code. Expecting %v but got %v", expectedStatusCode, w.Code)
+	}
+
+	if !strings.Contains(w.Body.String(), expectedBody) {
+		t.Errorf(`Wrong response. Expecting "%s" but got "%s"`, expectedBody, w.Body.String())
+	}
+}
+
+func TestPageWhenValid(t *testing.T) {
+	expectedStatusCode := 200
+	expectedBody := `{"message": "Forwarding page to integrations."}`
+
+	requestBody := `{
+		"name":"something.created",
+		"userID":"123",
+                "url":"http://www.example.com",
+		"properties": { "someCounter": 97 },
+		"timestamp": 12345678
+	}`
+	r, err := http.NewRequest("POST", "/page", strings.NewReader(requestBody))
+	if err != nil {
+		t.Fatal(err)
+	}
+	w := httptest.NewRecorder()
+
+	integration := &CalledIntegrationPage{t: t}
+	integrations.RegisterIntegration("test-only-integration-called", integration)
+	defer integrations.RemoveIntegration("test-only-integration-called")
+
+	Page(w, r)
+
+	if !integration.PageCalled {
+		t.Error("Page was not called on the integration")
+	}
+
+	if w.Code != expectedStatusCode {
+		t.Errorf("Wrong status code. Expecting %v but got %v", expectedStatusCode, w.Code)
+	}
+
+	if !strings.Contains(w.Body.String(), expectedBody) {
+		t.Errorf(`Wrong response. Expecting "%s" but got "%s"`, expectedBody, w.Body.String())
+	}
+}
+
+// FailingIntegrationPage is an integration that fails when called
+type FailingIntegrationPage struct {
+	FakeIntegration
+}
+
+// Page is failing in this case
+func (fi FailingIntegrationPage) Page(page integrations.Page) error {
+	return errors.New("some random error")
+}
+
+// Enabled returns true because this failing integraiton is enabled
+func (FailingIntegrationPage) Enabled() bool {
+	return true
+}
+
+type CalledIntegrationPage struct {
+	FakeIntegration
+	PageCalled bool
+	t          *testing.T
+}
+
+func (i *CalledIntegrationPage) Page(page integrations.Page) error {
+	i.PageCalled = true
+
+	expectedReceivedAtCloseTo := time.Now().Unix() - 5
+	if page.ReceivedAt < expectedReceivedAtCloseTo {
+		i.t.Errorf("ReceivedAt looks wrong. Expecting something close to %v but got %v", expectedReceivedAtCloseTo, page.ReceivedAt)
+	}
+
+	return nil
+}
+
+func (i CalledIntegrationPage) Enabled() bool {
+	return true
+}

--- a/integrations/drift/drift.go
+++ b/integrations/drift/drift.go
@@ -78,6 +78,11 @@ func (d Drift) Track(event integrations.Event) (err error) {
 	return
 }
 
+func (d Drift) Page(page integrations.Page) (err error) {
+	logrus.Errorf("NOT IMPLEMENTED: will send %#v to Drift\n", page)
+	return
+}
+
 // Enabled returns wether or not the Drift integration is enabled/configured
 func (Drift) Enabled() bool {
 	return orgID() != ""

--- a/integrations/drip/drip.go
+++ b/integrations/drip/drip.go
@@ -82,6 +82,11 @@ func (d Drip) Track(event integrations.Event) (err error) {
 	return
 }
 
+func (d Drip) Page(page integrations.Page) (err error) {
+	logrus.Errorf("NOT IMPLEMENTED: will send %#v to Mixpanel\n", page)
+	return
+}
+
 // Enabled returns wether or not the Drip integration is enabled/configured
 func (Drip) Enabled() bool {
 	return apiToken() != "" && accountID() != ""

--- a/integrations/integration.go
+++ b/integrations/integration.go
@@ -10,6 +10,7 @@ type Integration interface {
 	// Track forwards the event to the integration
 	Track(event Event) error
 
+	// Page forwards the page-view to the integration
 	Page(page Page) error
 
 	// Enabled returns wether or not the integration is enabled/configured
@@ -44,6 +45,7 @@ func (i Identification) Validate() (missingParameters []string) {
 	return
 }
 
+// Event defines the structure for the incoming event data from the API
 type Event struct {
 	// Name is the name of the event
 	Name string `json:"name"`
@@ -77,6 +79,7 @@ func (e Event) Validate() (missingParameters []string) {
 	return
 }
 
+// Page defines the structure for the incoming page-view data
 type Page struct {
 	// Name is the name of the page
 	Name string `json:"name"`

--- a/integrations/integration.go
+++ b/integrations/integration.go
@@ -10,6 +10,8 @@ type Integration interface {
 	// Track forwards the event to the integration
 	Track(event Event) error
 
+	Page(page Page) error
+
 	// Enabled returns wether or not the integration is enabled/configured
 	Enabled() bool
 }
@@ -70,6 +72,46 @@ func (e Event) Validate() (missingParameters []string) {
 	}
 
 	if e.Timestamp == 0 {
+		missingParameters = append(missingParameters, "timestamp")
+	}
+	return
+}
+
+type Page struct {
+	// Name is the name of the page
+	Name string `json:"name"`
+
+	// Unique user ID. Should not change, ever.
+	UserID string `json:"userID"`
+
+	// Unique user ID. Should not change, ever.
+	Url string `json:"url"`
+
+	// Properties are custom variables you can send with the page
+	Properties map[string]interface{} `json:"properties"`
+
+	// Timestamp of when the page-call originally triggered
+	Timestamp int64 `json:"timestamp"`
+
+	// ReceivedAt of when Forwardlytics received the page-call.
+	ReceivedAt int64 `json:"receivedAt"`
+}
+
+// Validate the content of the page to be sure it has everything that's needed
+func (p Page) Validate() (missingParameters []string) {
+	if p.Name == "" {
+		missingParameters = append(missingParameters, "name")
+	}
+
+	if p.Url == "" {
+		missingParameters = append(missingParameters, "url")
+	}
+
+	if p.UserID == "" {
+		missingParameters = append(missingParameters, "userID")
+	}
+
+	if p.Timestamp == 0 {
 		missingParameters = append(missingParameters, "timestamp")
 	}
 	return

--- a/integrations/intercom/intercom.go
+++ b/integrations/intercom/intercom.go
@@ -94,6 +94,11 @@ func (i Intercom) Track(event integrations.Event) (err error) {
 	return
 }
 
+func (d Intercom) Page(page integrations.Page) (err error) {
+	logrus.Errorf("NOT IMPLEMENTED: will send %#v to Intercom\n", page)
+	return
+}
+
 // Enabled returns wether or not the Intercom integration is enabled/configured
 func (i Intercom) Enabled() bool {
 	return apiKey() != "" && appID() != ""

--- a/integrations/mixpanel/mixpanel.go
+++ b/integrations/mixpanel/mixpanel.go
@@ -23,6 +23,11 @@ func (Mixpanel) Track(event integrations.Event) (err error) {
 	return
 }
 
+func (Mixpanel) Page(page integrations.Page) (err error) {
+	logrus.Errorf("NOT IMPLEMENTED: will send %#v to Mixpanel\n", page)
+	return
+}
+
 // Enabled returns wether or not the Mixpanel integration is enabled/configured
 func (Mixpanel) Enabled() bool {
 	return apiKey() != "" && token() != ""

--- a/main.go
+++ b/main.go
@@ -26,6 +26,7 @@ func main() {
 
 	http.Handle("/identify", handlers.AuthMiddleware(http.HandlerFunc(handlers.Identify)))
 	http.Handle("/track", handlers.AuthMiddleware(http.HandlerFunc(handlers.Track)))
+	http.Handle("/page", handlers.AuthMiddleware(http.HandlerFunc(handlers.Page)))
 	logrus.Infof("Forwardlytics started on port %v", port)
 	logrus.Fatal(http.ListenAndServe(":"+port, nil))
 }


### PR DESCRIPTION
* All integrations now respond to the page-endpoint

Didn't update the README as the track-endpoint is not documentet there either. Might be a good idea to document the api as the api grows, but maybe it should be done using a tool that is more apropriate (eg http://raml.org/ or similar)