### PR TITLE
Users are auto-created when /track is called with a non-existing user

### DIFF
--- a/integrations/intercom/intercom_test.go
+++ b/integrations/intercom/intercom_test.go
@@ -114,6 +114,7 @@ func TestIdentifyWhenFail(t *testing.T) {
 func TestTrack(t *testing.T) {
 	ic := Intercom{}
 	ic.Client = intercom.NewClient("", "")
+	ic.Service = &FakeIntercomAPIWhenCreate{}
 	es := &FakeIntercomEventsService{t: t}
 	ic.EventRepository = es
 
@@ -155,6 +156,7 @@ func TestTrack(t *testing.T) {
 func TestTrackWhenFail(t *testing.T) {
 	ic := Intercom{}
 	ic.Client = intercom.NewClient("", "")
+	ic.Service = &FakeIntercomAPIWhenCreate{}
 	es := &FakeIntercomEventsServiceFailing{t: t}
 	ic.EventRepository = es
 
@@ -217,6 +219,7 @@ func TestTrackWhenAPropertyIsAMap(t *testing.T) {
 	// https://docs.intercom.io/the-intercom-platform/tracking-events-in-intercom
 	ic := Intercom{}
 	ic.Client = intercom.NewClient("", "")
+	ic.Service = &FakeIntercomAPIWhenCreate{}
 	es := &FakeIntercomEventsService{t: t}
 	ic.EventRepository = es
 


### PR DESCRIPTION
Why:

* Intercom will not accept the event and will return a 404 error if
  the user doesn't exist, and the event will not be tracked

This change addresses the need by:

* https://github.com/jipiboily/forwardlytics/issues/48