### PR TITLE
Mixpanel integration and tests added

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,8 @@ To send to Drift:
 
 - set `DRIFT_ORG_ID=456` (ATM only possible to find by contacting the drift support dept)
 
-[Mixpanel][mixpanel] is probably going to be next.
+To send to[Mixpanel][mixpanel]:
+- set `MIXPANEL_TOKEN=123`
 
 ## Deployment
 

--- a/integrations/drip/drip.go
+++ b/integrations/drip/drip.go
@@ -46,9 +46,9 @@ func (d Drip) Identify(identification integrations.Identification) (err error) {
 	if identification.UserTraits["email"] == nil {
 		logrus.WithField("identification", identification).Error("Drip: Required field email is not present")
 		return errors.New("Email is required for doing a drip request")
-	} else {
-		s.Email = identification.UserTraits["email"].(string)
 	}
+
+	s.Email = identification.UserTraits["email"].(string)
 
 	s.UserId = string(identification.UserID)
 
@@ -57,7 +57,7 @@ func (d Drip) Identify(identification integrations.Identification) (err error) {
 	s.CustomFields["forwardlyticsReceivedAt"] = identification.ReceivedAt
 	s.CustomFields["forwardlyticsTimestamp"] = identification.Timestamp
 
-	payload, err := json.Marshal(map[string][]apiSubscriber{"subscribers": []apiSubscriber{s}})
+	payload, err := json.Marshal(map[string][]apiSubscriber{"subscribers": {s}})
 	err = d.api.request("POST", "subscribers", payload)
 	return
 }
@@ -74,7 +74,7 @@ func (d Drip) Track(event integrations.Event) (err error) {
 	e.Action = event.Name
 	e.OccurredAt = time.Unix(event.Timestamp, 0).Format("2006-01-02T15:04:05-0700")
 	e.Properties = event.Properties
-	payload, err := json.Marshal(map[string][]apiEvent{"events": []apiEvent{e}})
+	payload, err := json.Marshal(map[string][]apiEvent{"events": {e}})
 	if err != nil {
 		logrus.WithField("err", err).Fatal("Error marshalling drip event to json")
 	}
@@ -97,7 +97,7 @@ func (d Drip) Page(page integrations.Page) (err error) {
 	e.Action = "Page visited"
 	e.OccurredAt = time.Unix(page.Timestamp, 0).Format("2006-01-02T15:04:05-0700")
 	e.Properties = page.Properties
-	payload, err := json.Marshal(map[string][]apiEvent{"events": []apiEvent{e}})
+	payload, err := json.Marshal(map[string][]apiEvent{"events": {e}})
 	if err != nil {
 		logrus.WithField("err", err).Fatal("Error marshalling drip page-event to json")
 	}

--- a/integrations/intercom/intercom.go
+++ b/integrations/intercom/intercom.go
@@ -120,7 +120,7 @@ func (i Intercom) Track(event integrations.Event) (err error) {
 
 // Page tracks page views. Intercom doesn't support a special type for
 // this, so it's implemented as a special type of event
-func (p Intercom) Page(page integrations.Page) (err error) {
+func (i Intercom) Page(page integrations.Page) (err error) {
 	icPage := intercom.Event{}
 	icPage.UserID = page.UserID
 	icPage.EventName = "Page visited"
@@ -146,7 +146,7 @@ func (p Intercom) Page(page integrations.Page) (err error) {
 		icPage.Email = page.Properties["email"].(string)
 	}
 
-	err = p.EventRepository.Save(&icPage)
+	err = i.EventRepository.Save(&icPage)
 
 	if err != nil {
 		logrus.WithError(err).WithField("event", page).WithField("icPage", icPage).Error("Error while saving event on Intercom")

--- a/integrations/mixpanel/README.md
+++ b/integrations/mixpanel/README.md
@@ -1,0 +1,13 @@
+# Mixpanel integration for Forwardlytics
+
+## Configuration
+
+To enable the Mixpanel integration, set these environment variable:
+
+```
+MIXPANEL_TOKEN=XYZ
+```
+
+The value for `MIXPANEL_TOKEN` can be found under "<your username>"
+(top right menu in the mixpanel dashboard) -> "Project settings" under
+"Token"

--- a/integrations/mixpanel/mixpanel.go
+++ b/integrations/mixpanel/mixpanel.go
@@ -1,7 +1,13 @@
 package mixpanel
 
 import (
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"io/ioutil"
+	"net/http"
 	"os"
+	"time"
 
 	"github.com/Sirupsen/logrus"
 	"github.com/jipiboily/forwardlytics/integrations"
@@ -9,32 +15,164 @@ import (
 
 // Mixpanel integration
 type Mixpanel struct {
+	api service
+}
+
+type mixpanelAPIProduction struct {
+	Url string
+}
+
+type service interface {
+	request(string, string, []byte) error
+}
+
+type apiSubscriber struct {
+	CustomFields map[string]interface{} `json:"$set"`
+	UserId       string                 `json:"$distinct_id"`
+	Token        string                 `json:"$token"`
+	Name         string                 `json:"$name"`
+	Email        string                 `json:"$email"`
+}
+
+type apiEvent struct {
+	Event      string                 `json:"event"`
+	Properties map[string]interface{} `json:"properties"`
 }
 
 // Identify forwards and identify call to Mixpanel
-func (Mixpanel) Identify(identification integrations.Identification) (err error) {
-	logrus.Errorf("NOT IMPLEMENTED: will send %#v to Mixpanel\n", identification)
+func (m Mixpanel) Identify(identification integrations.Identification) (err error) {
+	s := apiSubscriber{}
+	s.UserId = string(identification.UserID)
+	s.Token = token()
+
+	if email, ok := identification.UserTraits["email"]; ok {
+		s.Email = email.(string)
+		delete(identification.UserTraits, "email")
+	}
+
+	if name, ok := identification.UserTraits["name"]; ok {
+		s.Name = name.(string)
+		delete(identification.UserTraits, "name")
+	}
+
+	// Add custom attributes
+	s.CustomFields = identification.UserTraits
+	s.CustomFields["forwardlyticsReceivedAt"] = identification.ReceivedAt
+	s.CustomFields["forwardlyticsTimestamp"] = identification.Timestamp
+
+	payload, err := json.Marshal(s)
+	err = m.api.request("GET", "engage", payload)
 	return
 }
 
 // Track forwards the event to Mixpanel
-func (Mixpanel) Track(event integrations.Event) (err error) {
-	logrus.Errorf("NOT IMPLEMENTED: will send %#v to Mixpanel\n", event)
+func (m Mixpanel) Track(event integrations.Event) (err error) {
+	// Events that are more than 5 years ago will fail in the mixpanel api
+	fiveYearsAgo := time.Now().AddDate(-5, 0, 0).Unix()
+	if event.Timestamp < fiveYearsAgo {
+		logrus.Error("Mixpanel won't accept events that are older than 5 years")
+		return errors.New("Mixpanel doesn't support importing events with a timestamp more than 5 years ago")
+	}
+
+	e := apiEvent{}
+	e.Event = event.Name
+	event.Properties["forwardlyticsReceivedAt"] = event.ReceivedAt
+	event.Properties["time"] = event.Timestamp
+	event.Properties["token"] = token()
+	event.Properties["distinct_id"] = event.UserID
+	delete(event.Properties, "email")
+	e.Properties = event.Properties
+	payload, err := json.Marshal(e)
+	if err != nil {
+		logrus.WithField("err", err).Fatal("Error marshalling Mixpanel event to json")
+		return
+	}
+
+	// Strange design choice in the mixpanel api: Need to use a
+	// different endpoint if the timestamp is more than 5 days
+	// ago. Submitting all events older than 5 days to the
+	// 'import'-endpoint (see:
+	// http://mixpanel.com/help/reference/http "Tracking via
+	// HTTP")
+	fiveDaysAgo := time.Now().AddDate(0, 0, -5).Unix()
+	var endpoint string
+	if event.Timestamp > fiveDaysAgo {
+		endpoint = "track"
+	} else {
+		endpoint = "import"
+	}
+
+	err = m.api.request("GET", endpoint, payload)
 	return
 }
 
-func (Mixpanel) Page(page integrations.Page) (err error) {
-	logrus.Errorf("NOT IMPLEMENTED: will send %#v to Mixpanel\n", page)
+// Page forwards the page-events to Mixpanel
+func (m Mixpanel) Page(page integrations.Page) (err error) {
+	// Mixpanel has no special api for Page events, so just pass on the Page-event to Track
+	// Name is the name of the page
+	pageEvent := integrations.Event{}
+	pageEvent.Name = page.Name
+	pageEvent.UserID = page.UserID
+	pageEvent.Properties = page.Properties
+	pageEvent.Properties["url"] = page.Url
+	pageEvent.Properties["event"] = "page"
+	pageEvent.Timestamp = page.Timestamp
+	pageEvent.ReceivedAt = page.ReceivedAt
+	err = m.Track(pageEvent)
 	return
 }
 
 // Enabled returns wether or not the Mixpanel integration is enabled/configured
 func (Mixpanel) Enabled() bool {
-	return apiKey() != "" && token() != ""
+	return token() != ""
 }
 
-func apiKey() string {
-	return os.Getenv("MIXPANEL_API_KEY")
+func (api mixpanelAPIProduction) request(method string, endpoint string, payload []byte) (err error) {
+	apiUrl := api.Url + endpoint
+	req, err := http.NewRequest(method, apiUrl, nil)
+	// Mixpanel needs the request to be GET http://<api-url>?data=<base64-encoded payload>
+	q := req.URL.Query()
+	logrus.Info(base64.StdEncoding.EncodeToString(payload))
+	q.Add("data", base64.StdEncoding.EncodeToString(payload))
+
+	// Hack, when using the /import-endpoint api_key must be
+	// passed as a query param as well
+	if endpoint == "import" {
+		q.Add("api_key", token())
+	}
+
+	req.URL.RawQuery = q.Encode()
+
+	client := &http.Client{}
+	resp, err := client.Do(req)
+	if resp != nil {
+		defer resp.Body.Close()
+	}
+	if err != nil {
+		logrus.WithError(err).WithField("method", method).WithField("endpoint", endpoint).WithField("payload", string(payload[:])).Error("Error sending request to Mixpanel api")
+		return
+	}
+
+	responseBody, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		logrus.WithError(err).WithField("method", method).WithField("endpoint", endpoint).WithField("payload", string(payload[:])).Error("Error reading body in Mixpanel response")
+		return err
+	}
+
+	// Mixpanel returns a 200OK with a body == 0 when things go wrong
+	if resp.StatusCode != http.StatusOK || string(responseBody) == "0" {
+		logrus.WithField("method", method).WithField("endpoint", endpoint).WithField("payload", string(payload[:])).WithFields(
+			logrus.Fields{
+				"response":    string(responseBody),
+				"HTTP-status": resp.StatusCode}).Error("Mixpanel api returned errors")
+	}
+
+	logrus.WithField("method", method).WithField("endpoint", endpoint).WithField("payload", string(payload[:])).WithFields(
+		logrus.Fields{
+			"response":    string(responseBody),
+			"HTTP-status": resp.StatusCode}).Info("Sent stuff to Mixpanel ", string(req.URL.String()))
+
+	return
 }
 
 func token() string {
@@ -42,5 +180,7 @@ func token() string {
 }
 
 func init() {
-	integrations.RegisterIntegration("mixpanel", Mixpanel{})
+	mixpanel := Mixpanel{}
+	mixpanel.api = &mixpanelAPIProduction{Url: "http://api.mixpanel.com/"}
+	integrations.RegisterIntegration("mixpanel", mixpanel)
 }

--- a/integrations/mixpanel/mixpanel_test.go
+++ b/integrations/mixpanel/mixpanel_test.go
@@ -1,0 +1,214 @@
+package mixpanel
+
+import (
+	"os"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/jipiboily/forwardlytics/integrations"
+)
+
+func TestToken(t *testing.T) {
+	m := Mixpanel{}
+	if m.Enabled() {
+		t.Error("Mixpanel shouldn't be enabled without an api-token from ENV")
+	}
+
+	os.Setenv("MIXPANEL_TOKEN", "321")
+	if !m.Enabled() {
+		t.Error("Mixpanel should be enabled when an api-token is set in ENV")
+	}
+
+	if token() != "321" {
+		t.Errorf("Error in api-token, expected 321, got: %s", token())
+	}
+}
+
+func TestIdentify(t *testing.T) {
+	os.Setenv("MIXPANEL_TOKEN", "321")
+	m := Mixpanel{}
+	api := APIMock{Url: "http://www.example.com"}
+	m.api = &api
+	identification := integrations.Identification{
+		UserID: "123",
+		UserTraits: map[string]interface{}{
+			"email": "john@example.com",
+			"name":  "John Candy",
+		},
+		Timestamp:  1234567,
+		ReceivedAt: 8765432,
+	}
+	err := m.Identify(identification)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if api.Method != "GET" {
+		t.Errorf("Expected method to be GET, was: %v", api.Method)
+	}
+
+	if api.Endpoint != "engage" {
+		t.Errorf("Expected endpoint to be engage, was: %v", api.Endpoint)
+	}
+
+	expectedPayload := `{"$set":{"forwardlyticsReceivedAt":8765432,"forwardlyticsTimestamp":1234567},"$distinct_id":"123","$token":"321","$name":"John Candy","$email":"john@example.com"}`
+	if string(api.Payload) != expectedPayload {
+		t.Errorf("Expected payload: "+string(expectedPayload)+" got: %s", api.Payload)
+	}
+}
+
+func TestTrackRecentEvent(t *testing.T) {
+	os.Setenv("MIXPANEL_TOKEN", "321")
+	m := Mixpanel{}
+	api := APIMock{Url: "http://www.example.com"}
+	m.api = &api
+
+	timestampForTest := time.Now().Unix()
+
+	event := integrations.Event{
+		Name:   "account.created",
+		UserID: "123",
+		Properties: map[string]interface{}{
+			"email": "john@example.com",
+		},
+		Timestamp:  timestampForTest,
+		ReceivedAt: 65,
+	}
+
+	err := m.Track(event)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if api.Method != "GET" {
+		t.Errorf("Expected method to be GET, was: %v", api.Method)
+	}
+
+	if api.Endpoint != "track" {
+		t.Errorf("Expected endpoint to be track, was: %v", api.Endpoint)
+	}
+
+	expectedPayload := "{\"event\":\"account.created\",\"properties\":{\"distinct_id\":\"123\",\"forwardlyticsReceivedAt\":65,\"time\":" + strconv.Itoa(int(timestampForTest)) + ",\"token\":\"321\"}}"
+	if string(api.Payload) != expectedPayload {
+		t.Errorf("Expected payload: "+string(expectedPayload)+" got: %s", api.Payload)
+	}
+}
+
+func TestTrackEventOlderThanFiveDays(t *testing.T) {
+	os.Setenv("MIXPANEL_TOKEN", "321")
+	m := Mixpanel{}
+	api := APIMock{Url: "http://www.example.com"}
+	m.api = &api
+
+	timestampForTest := time.Now().AddDate(0, 0, -6).Unix()
+
+	event := integrations.Event{
+		Name:   "account.created",
+		UserID: "123",
+		Properties: map[string]interface{}{
+			"email": "john@example.com",
+		},
+		Timestamp:  timestampForTest,
+		ReceivedAt: 65,
+	}
+
+	err := m.Track(event)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if api.Method != "GET" {
+		t.Errorf("Expected method to be GET, was: %v", api.Method)
+	}
+
+	if api.Endpoint != "import" {
+		t.Errorf("Expected endpoint to be import, was: %v", api.Endpoint)
+	}
+
+	expectedPayload := "{\"event\":\"account.created\",\"properties\":{\"distinct_id\":\"123\",\"forwardlyticsReceivedAt\":65,\"time\":" + strconv.Itoa(int(timestampForTest)) + ",\"token\":\"321\"}}"
+	if string(api.Payload) != expectedPayload {
+		t.Errorf("Expected payload: "+string(expectedPayload)+" got: %s", api.Payload)
+	}
+}
+
+func TestTrackEventOlderThanFiveYears(t *testing.T) {
+	os.Setenv("MIXPANEL_TOKEN", "321")
+	m := Mixpanel{}
+	api := APIMock{Url: "http://www.example.com"}
+	m.api = &api
+
+	timestampForTest := time.Now().AddDate(-6, 0, 0).Unix()
+
+	event := integrations.Event{
+		Name:   "account.created",
+		UserID: "123",
+		Properties: map[string]interface{}{
+			"email": "john@example.com",
+		},
+		Timestamp:  timestampForTest,
+		ReceivedAt: 65,
+	}
+
+	err := m.Track(event)
+	if err == nil {
+		t.Error("Events with a timestamp more than 5 years ago shouldn't be accepted")
+	}
+}
+
+// Test page
+func TestPage(t *testing.T) {
+	os.Setenv("MIXPANEL_TOKEN", "321")
+	m := Mixpanel{}
+	api := APIMock{Url: "http://www.example.com"}
+	m.api = &api
+
+	timestampForTest := time.Now().Unix()
+
+	page := integrations.Page{
+		Name:   "Homepage",
+		UserID: "123",
+		Url:    "http://www.example.com",
+		Properties: map[string]interface{}{
+			"email": "john@example.com",
+		},
+		Timestamp:  timestampForTest,
+		ReceivedAt: 65,
+	}
+
+	err := m.Page(page)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if api.Method != "GET" {
+		t.Errorf("Expected method to be GET, was: %v", api.Method)
+	}
+
+	if api.Endpoint != "track" {
+		t.Errorf("Expected endpoint to be track, was: %v", api.Endpoint)
+	}
+
+	expectedPayload := "{\"event\":\"Homepage\",\"properties\":{\"distinct_id\":\"123\",\"event\":\"page\",\"forwardlyticsReceivedAt\":65,\"time\":" + strconv.Itoa(int(timestampForTest)) + ",\"token\":\"321\",\"url\":\"http://www.example.com\"}}"
+	if string(api.Payload) != expectedPayload {
+		t.Errorf("Expected payload: "+string(expectedPayload)+" got: %s", api.Payload)
+	}
+}
+
+func TestRequest(t *testing.T) {
+
+}
+
+type APIMock struct {
+	Url      string
+	Method   string
+	Endpoint string
+	Payload  []byte
+}
+
+func (api *APIMock) request(method string, endpoint string, payload []byte) error {
+	api.Method = method
+	api.Endpoint = endpoint
+	api.Payload = payload
+	return nil
+}


### PR DESCRIPTION
A few things to notice:

* The Mixpanel-api uses GET for everything and it's over unencryptet http
* Events older than 5 years will fail to import (this isn't supported
* by the api)
* The api is documented here: https://mixpanel.com/help/reference/http

I made everything behave as consistently with the other integrations as possible in spite of the kinda strange Mixpanel-api. Tell me what you think, and I'll fix any issues that pops up 😃 